### PR TITLE
[Feature] Resolve OBIS names and more

### DIFF
--- a/etc/smartmeter.service.default
+++ b/etc/smartmeter.service.default
@@ -1,6 +1,6 @@
 [Unit]
 Description=SmartMeter
-Documentation=https://gitlab.com/smart-home-tools/smartmetertomqtt
+Documentation=https://github.com/oetken/smartmetertomqtt
 
 [Service]
 Type=simple

--- a/inc/IMessageFilter.hpp
+++ b/inc/IMessageFilter.hpp
@@ -9,6 +9,8 @@
 class IMessageFilter {
 public:
     virtual QVariant filter(QVariant value) = 0;
+    virtual QString  rename(QString name) { return name; };
+    virtual QString  type() = 0;
 };
 
 #endif //SMARTMETERTOMQTT_IMESSAGEFILTER_HPP

--- a/inc/MessageFilterDelta.hpp
+++ b/inc/MessageFilterDelta.hpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,23 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#ifndef SMARTMETERTOMQTT_MESSAGEFILTERDELTA_HPP
+#define SMARTMETERTOMQTT_MESSAGEFILTERDELTA_HPP
 
-#include <QObject>
-#include <QVariant>
 #include "IMessageFilter.hpp"
-#include <QMultiHash>
 
-class IMessageSource : public QObject{
-    Q_OBJECT
+class MessageFilterDelta : public IMessageFilter{
 public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
+    explicit MessageFilterDelta();
+    explicit MessageFilterDelta(QString m_name);
+    QVariant filter(QVariant value) override;
+    QString  rename(QString name) override;
+    QString  type() override { return "Delta"; };
 
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
+private:
+    QVariant m_lastValue;
+    QString m_name;
 };
 
 
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#endif //SMARTMETERTOMQTT_MESSAGEFILTERSKIP_HPP

--- a/inc/MessageFilterIgnore.hpp
+++ b/inc/MessageFilterIgnore.hpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,17 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#ifndef SMARTMETERTOMQTT_MESSAGEFILTERIGNORE_HPP
+#define SMARTMETERTOMQTT_MESSAGEFILTERIGNORE_HPP
 
-#include <QObject>
-#include <QVariant>
 #include "IMessageFilter.hpp"
-#include <QMultiHash>
 
-class IMessageSource : public QObject{
-    Q_OBJECT
+class MessageFilterIgnore : public IMessageFilter{
 public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
-
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
+    explicit MessageFilterIgnore();
+    QVariant filter(QVariant value) override;
+    QString  type() override { return "Ignore"; };
 };
 
 
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#endif //SMARTMETERTOMQTT_MESSAGEFILTERSKIP_HPP

--- a/inc/MessageFilterMean.hpp
+++ b/inc/MessageFilterMean.hpp
@@ -24,7 +24,7 @@ class MessageFilterMean : public IMessageFilter {
 public:
     QVariant filter(QVariant value) override;
     explicit MessageFilterMean(uint32_t sampleCount, double threshold = std::nan(""), uint32_t postThresholdIncreaseSampleCount = 0);
-
+    QString  type() override { return "Mean"; };
 private:
     QVariant getMeanValue(bool force = false);
 

--- a/inc/MessageFilterSkip.hpp
+++ b/inc/MessageFilterSkip.hpp
@@ -22,11 +22,14 @@
 
 class MessageFilterSkip : public IMessageFilter{
 public:
-    explicit MessageFilterSkip(uint32_t skipCount);
+    explicit MessageFilterSkip(uint32_t skipCount, QString name);
     QVariant filter(QVariant value) override;
-
+    QString rename(QString name) override;
+    QString  type() override { return "Skip"; };
+ 
 private:
     uint32_t m_skipCount;
+    QString m_name;
     uint32_t m_skipped{};
 };
 

--- a/inc/MessageSourceMbusSerial.hpp
+++ b/inc/MessageSourceMbusSerial.hpp
@@ -32,6 +32,7 @@ public:
 private slots:
     void readData();
 private:
+    void processFilters(const QString reference, auto value);
     void handleXmlData(char * data);
     QTimer m_timer;
     QString m_device;

--- a/inc/MessageSourceMbusSerial.hpp
+++ b/inc/MessageSourceMbusSerial.hpp
@@ -32,7 +32,7 @@ public:
 private slots:
     void readData();
 private:
-    void processFilters(const QString reference, auto value);
+    void processFilters(const QString reference, const QString value);
     void handleXmlData(char * data);
     QTimer m_timer;
     QString m_device;

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -1,0 +1,52 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OBISCODE_H
+#define OBISCODE_H
+
+#include <QString>
+#include "sml/sml_octet_string.h"
+
+class ObisCode
+{
+    
+    public:
+        ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range);
+        ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group);
+        ObisCode(uint8_t channel, uint8_t value, uint8_t quantiy, uint8_t group);
+        ObisCode(uint8_t value, uint8_t quantiy, uint8_t group);
+        ObisCode(octet_string* obis_code);
+
+        bool isValid() const {return valid_;}
+        bool hasText() const {return isValid() && false;} //TODO: Has to be implmented!
+        QString getName() const {return QString();} //TODO: Has to be implmented!
+        QString toObisString() const;
+        QString toReadableString() const;
+        QString toString() const;
+
+    private:
+        uint8_t medium_;
+        uint8_t channel_;
+        uint8_t value_;
+        uint8_t quantity_;
+        uint8_t group_;
+        uint8_t range_;
+        bool    valid_;
+};
+
+#endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -36,8 +36,10 @@ class ObisCode
         ObisCode(octet_string* obis_code);
 
         bool isValid() const {return valid_;}
-        bool hasText() const {return isValid() && names_.contains(*this);} 
-        const QString getName() const {return names_.value(*this);}
+        bool hasName() const {return isValid() && names_.contains(*this);} 
+        bool hasPostfix() const {return isValid() && postfixes_.contains(this.range_);} 
+        const QString getName() const {return hasName() ? names_.value(*this) : "";}
+        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this.range_) : '';}
         const QString toObisString() const;
         const QString toReadableString() const;
         const QString toString() const;
@@ -52,16 +54,20 @@ class ObisCode
         bool    valid_;
 
         static const QHash<ObisCode,QString> names_;
+        static const QHash<uint8_t,QString> postfixes_;
 };
 
 inline bool operator==(const ObisCode &code1, const ObisCode &code2)
 {
-    return code1.toObisString() == code2.toObisString();
+    return code1.medium_   == code2.medium_  &&
+           code1.channel_  == code2.channel_ &&
+           code1.value_    == code2.value_   &&
+           code1.quantity_ == code2.quantity_ &&
+           code1.group_    == code2.group_ ;
 }
 
 inline uint qHash(const ObisCode &key, uint seed)
 {
-    //return qHash(key.toObisString().toLatin1(), seed ^ 0xb036);
     return qHash(key.toObisString(), seed ^ 0xb036);
 }
 #endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -20,7 +20,10 @@
 #define OBISCODE_H
 
 #include <QString>
+#include <QHash>
 #include "sml/sml_octet_string.h"
+
+class ObisCode;
 
 class ObisCode
 {
@@ -33,11 +36,11 @@ class ObisCode
         ObisCode(octet_string* obis_code);
 
         bool isValid() const {return valid_;}
-        bool hasText() const {return isValid() && false;} //TODO: Has to be implmented!
-        QString getName() const {return QString();} //TODO: Has to be implmented!
-        QString toObisString() const;
-        QString toReadableString() const;
-        QString toString() const;
+        bool hasText() const {return isValid() && names_.contains(*this);} 
+        const QString getName() const {return names_.value(*this);}
+        const QString toObisString() const;
+        const QString toReadableString() const;
+        const QString toString() const;
 
     private:
         uint8_t medium_;
@@ -47,6 +50,18 @@ class ObisCode
         uint8_t group_;
         uint8_t range_;
         bool    valid_;
+
+        static const QHash<ObisCode,QString> names_;
 };
 
+inline bool operator==(const ObisCode &code1, const ObisCode &code2)
+{
+    return code1.toObisString() == code2.toObisString();
+}
+
+inline uint qHash(const ObisCode &key, uint seed)
+{
+    //return qHash(key.toObisString().toLatin1(), seed ^ 0xb036);
+    return qHash(key.toObisString(), seed ^ 0xb036);
+}
 #endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -44,7 +44,9 @@ class ObisCode
         const QString toReadableString() const;
         const QString toString() const;
 
-    protected:
+        friend bool operator==(const ObisCode &lhs, const ObisCode &rhs);
+
+    private:
         uint8_t medium_;
         uint8_t channel_;
         uint8_t value_;
@@ -58,13 +60,13 @@ class ObisCode
         static const QHash<uint8_t,QString> postfixes_;
 };
 
-inline bool operator==(const ObisCode &code1, const ObisCode &code2)
+inline bool operator==(const ObisCode &lhs, const ObisCode &rhs)
 {
-    return code1.medium_   == code2.medium_  &&
-           code1.channel_  == code2.channel_ &&
-           code1.value_    == code2.value_   &&
-           code1.quantity_ == code2.quantity_ &&
-           code1.group_    == code2.group_ ;
+    return lhs.medium_   == rhs.medium_  &&
+           lhs.channel_  == rhs.channel_ &&
+           lhs.value_    == rhs.value_   &&
+           lhs.quantity_ == rhs.quantity_ &&
+           lhs.group_    == rhs.group_ ;
 }
 
 inline uint qHash(const ObisCode &key, uint seed)

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -37,14 +37,14 @@ class ObisCode
 
         bool isValid() const {return valid_;}
         bool hasName() const {return isValid() && names_.contains(*this);} 
-        bool hasPostfix() const {return isValid() && postfixes_.contains(this.range_);} 
+        bool hasPostfix() const {return isValid() && postfixes_.contains(this->range_);} 
         const QString getName() const {return hasName() ? names_.value(*this) : "";}
-        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this.range_) : '';}
+        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this->range_) : "";}
         const QString toObisString() const;
         const QString toReadableString() const;
         const QString toString() const;
 
-    private:
+    protected:
         uint8_t medium_;
         uint8_t channel_;
         uint8_t value_;
@@ -53,6 +53,7 @@ class ObisCode
         uint8_t range_;
         bool    valid_;
 
+    private:
         static const QHash<ObisCode,QString> names_;
         static const QHash<uint8_t,QString> postfixes_;
 };

--- a/src/MessageFilterDelta.cpp
+++ b/src/MessageFilterDelta.cpp
@@ -1,0 +1,42 @@
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "MessageFilterDelta.hpp"
+
+MessageFilterDelta::MessageFilterDelta() : m_lastValue(QVariant()), m_name(QString()){
+}
+
+MessageFilterDelta::MessageFilterDelta(QString name) : m_lastValue(QVariant()), m_name(name){
+}
+
+QString MessageFilterDelta::rename(QString name) {
+    if (m_name.isEmpty())
+      return name;
+    return m_name;
+}
+
+QVariant MessageFilterDelta::filter(QVariant value) {
+    QVariant delta = QVariant();
+    if (!m_lastValue.isNull() && m_lastValue.canConvert<double>() && value.canConvert<double>())
+      {
+        double old_val = m_lastValue.value<double>();
+        double new_val = value.value<double>();
+        delta.setValue<double>(new_val - old_val);
+      }
+    m_lastValue = value;
+    return delta;
+}

--- a/src/MessageFilterDelta.cpp
+++ b/src/MessageFilterDelta.cpp
@@ -31,12 +31,19 @@ QString MessageFilterDelta::rename(QString name) {
 
 QVariant MessageFilterDelta::filter(QVariant value) {
     QVariant delta = QVariant();
-    if (!m_lastValue.isNull() && m_lastValue.canConvert<double>() && value.canConvert<double>())
+
+    if (value.canConvert<double>())
+    {
+      double new_val = value.value<double>();
+
+      if (!m_lastValue.isNull() && m_lastValue.canConvert<double>())
       {
         double old_val = m_lastValue.value<double>();
-        double new_val = value.value<double>();
         delta.setValue<double>(new_val - old_val);
       }
-    m_lastValue = value;
+
+      m_lastValue.setValue<double>(new_val);
+    }
+    
     return delta;
 }

--- a/src/MessageFilterIgnore.cpp
+++ b/src/MessageFilterIgnore.cpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,11 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#include "MessageFilterIgnore.hpp"
 
-#include <QObject>
-#include <QVariant>
-#include "IMessageFilter.hpp"
-#include <QMultiHash>
+MessageFilterIgnore::MessageFilterIgnore(){
+}
 
-class IMessageSource : public QObject{
-    Q_OBJECT
-public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
-
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
-};
-
-
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+QVariant MessageFilterIgnore::filter(QVariant value) {
+    return QVariant();
+}

--- a/src/MessageFilterSkip.cpp
+++ b/src/MessageFilterSkip.cpp
@@ -17,7 +17,13 @@
  */
 #include "MessageFilterSkip.hpp"
 
-MessageFilterSkip::MessageFilterSkip(uint32_t skipCount) : m_skipCount(skipCount){
+MessageFilterSkip::MessageFilterSkip(uint32_t skipCount, QString name) : m_skipCount(skipCount), m_name(name){
+}
+
+QString MessageFilterSkip::rename(QString name) {
+  if (m_name.isEmpty())
+    return name;
+  return m_name;
 }
 
 QVariant MessageFilterSkip::filter(QVariant value) {

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -261,10 +261,10 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
                             qDebug() << m_topic + "/" + string + "/" + variant.toString();
                         }
                     }
-                    else {
-                        emit messageReceived(m_topic + "/" + string, variant);
-                        qDebug() << m_topic + "/" + string + "/" + variant.toString();
-                    }
+                    // else {
+                    //     emit messageReceived(m_topic + "/" + string, variant);
+                    //     qDebug() << m_topic + "/" + string + "/" + variant.toString();
+                    // }
                 }
             } else {
                 qDebug() << m_topic + "/" + reference + "/" + value;

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -243,32 +243,32 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
                 {
                     qDebug() << "Running filter" << filter->type();
                     QVariant variant = filter->filter(value);
-                    reference = filter->rename(reference);
+                    QString string = filter->rename(reference);
                     if(!variant.isNull())
                     {
                         if(variant.canConvert<QVariantList>())
                         {
                             for(QVariant element : variant.toList())
                             {
-                                emit messageReceived(m_topic + "/" + reference, variant);
-                                qDebug() << m_topic + "/" + reference + "/" + variant.toString();
+                                emit messageReceived(m_topic + "/" + string, variant);
+                                qDebug() << m_topic + "/" + string + "/" + variant.toString();
 
                                 emit messageReceived(m_topic + "/" + name, element);
                                 qDebug() << "filtered" << name << element;
                             }
                         } else {
-                            emit messageReceived(m_topic + "/" + reference, variant);
-                            qDebug() << m_topic + "/" + reference + "/" + variant.toString();
+                            emit messageReceived(m_topic + "/" + string, variant);
+                            qDebug() << m_topic + "/" + string + "/" + variant.toString();
                         }
                     }
                     else {
-                        emit messageReceived(m_topic + "/" + id + "/" + name, variant);
-                        qDebug() << m_topic + "/" + id + "/" + name + "/" + variant.toString();
+                        emit messageReceived(m_topic + "/" + string, variant);
+                        qDebug() << m_topic + "/" + string + "/" + variant.toString();
                     }
                 }
             } else {
-                qDebug() << m_topic + "/" + id + "/" + name + "/" + value;
-                emit messageReceived(m_topic + "/" + id + "/" + name, value);
+                qDebug() << m_topic + "/" + reference + "/" + value;
+                emit messageReceived(m_topic + "/" + reference, value);
             }
         }
     }

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -275,8 +275,8 @@ void MessageSourceMbusSerial::processFilters(const QString reference, auto value
                         emit messageReceived(m_topic + "/" + string, variant);
                         qDebug() << m_topic + "/" + string + "/" + variant.toString();
 
-                        emit messageReceived(m_topic + "/" + name, element);
-                        qDebug() << "filtered" << name << element;
+                        emit messageReceived(m_topic + "/" + string, element);
+                        qDebug() << "filtered" << string << element;
                     }
                 } else {
                     emit messageReceived(m_topic + "/" + string, variant);

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -235,7 +235,7 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
             auto name = children.at(i).nodeName();
             QString reference = "slaveinfo/" + name;
 
-            processFilters(name, value);
+            processFilters(reference, value);
         }
     }
 

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -256,7 +256,7 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
     }
 }
 
-void MessageSourceMbusSerial::processFilters(const QString reference, auto value){
+void MessageSourceMbusSerial::processFilters(const QString reference, const QString value){
     qDebug() << "Processing MBUS value" << reference;
 
     if(m_filters.contains(reference))

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -142,10 +142,10 @@ void MessageSourceSml::handleReadReady()
                                     qDebug() << "filtered" << string << variant;
                                 }
                             }
-                            else {
-                                emit messageReceived(topicBase_ + "/" + string, variant);
-                                qDebug() << "filtered" << string << variant;
-                            }
+                            // else {
+                            //     emit messageReceived(topicBase_ + "/" + string, variant);
+                            //     qDebug() << "filtered" << string << variant;
+                            // }
                         }
                       } else {
                           emit messageReceived(topicBase_ + "/" + name, value);

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -127,24 +127,24 @@ void MessageSourceSml::handleReadReady()
                         for(auto filter : filters)
                         {
                             QVariant variant = filter->filter(value);
-                            name = filter->rename(name);
+                            QString string = filter->rename(name);
                             if(!variant.isNull())
                             {
                                 if(variant.canConvert<QVariantList>())
                                 {
                                     for(QVariant element : variant.toList())
                                     {
-                                        emit messageReceived(topicBase_ + "/" + name, element);
-                                        qDebug() << "filtered" << name << element;
+                                        emit messageReceived(topicBase_ + "/" + string, element);
+                                        qDebug() << "filtered" << string << element;
                                     }
                                 } else {
-                                    emit messageReceived(topicBase_ + "/" + name, variant);
-                                    qDebug() << "filtered" << name << variant;
+                                    emit messageReceived(topicBase_ + "/" + string, variant);
+                                    qDebug() << "filtered" << string << variant;
                                 }
                             }
                             else {
-                                emit messageReceived(topicBase_ + "/" + name, variant);
-                                qDebug() << "filtered" << name << variant;
+                                emit messageReceived(topicBase_ + "/" + string, variant);
+                                qDebug() << "filtered" << string << variant;
                             }
                         }
                       } else {

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -123,7 +123,14 @@ void MessageSourceSml::handleReadReady()
                       QString code = obis.toObisString();
                       if(m_filters.contains(name) || m_filters.contains(code))
                       {
-                        QVariant variant = m_filters.contains(code) ? m_filters[code]->filter(value) : m_filters[name]->filter(value);
+                        QVariant variant;
+                        if(m_filters.contains(name))
+                        {
+                            variant = m_filters[name]->filter(value);
+                        }else{
+                            variant = m_filters[code]->filter(value);
+                        }
+
                         if(!variant.isNull())
                         {
                             if(variant.canConvert<QVariantList>())
@@ -156,4 +163,5 @@ void MessageSourceSml::handleReadReady()
         readData_.remove(0, readData_.length() - sizeof(startPattern_));
     }
 }
+
 

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -20,16 +20,24 @@
 #include <QTextStream>
 
 const QHash<ObisCode,QString> ObisCode::names_{
-{{1,0,16,7,0}, {"power"}},
-{{1,0,1,8,0}, {"total_consumption"}},
-{{1,0,1,8,1}, {"total_consumption_ch1"}},
-{{1,0,1,8,2}, {"total_consumption_ch2"}},
-{{1,0,2,8,0}, {"total_feed"}},
-{{1,0,2,8,1}, {"total_feed_ch1"}},
-{{1,0,2,8,2}, {"total_feed_ch2"}},
-{{1,0,0,0,9}, {"serial"}},
-{{129,129,199,130,5}, {"public_key"}},
-{{129,129,199,130,3}, {"manufacture"}},
+    {{1,0,16,7,0}, {"power"}},
+    {{1,0,1,8,0}, {"total_consumption"}},
+    {{1,0,1,8,1}, {"total_consumption_ch1"}},
+    {{1,0,1,8,2}, {"total_consumption_ch2"}},
+    {{1,0,2,8,0}, {"total_feed"}},
+    {{1,0,2,8,1}, {"total_feed_ch1"}},
+    {{1,0,2,8,2}, {"total_feed_ch2"}},
+    {{1,0,0,0,9}, {"serial"}},
+    {{129,129,199,130,5}, {"public_key"}},
+    {{129,129,199,130,3}, {"manufacture"}}
+};
+
+const QHash<uint8_t,QString> ObisCode::postfixes_{
+    {{96},{"_last1d"}},
+    {{97},{"_last7d"}},
+    {{98},{"_last30d"}},
+    {{99},{"_last365d"}},
+    {{100},{"_since_rst"}},
 };
 
 ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
@@ -87,7 +95,11 @@ const QString ObisCode::toReadableString() const
 
     if (isValid())
     {
-        string = getName();
+        if (hasName()){
+            string = getName() + getPostfix();
+        }else{
+            string = toObisString();
+        }
     }else{
         string = QString("Invalid OBIS Code!");
     }
@@ -99,7 +111,7 @@ const QString ObisCode::toString() const
 {
     QString string;
 
-    if (hasText())
+    if (hasName())
     {
         string = toReadableString();
     }else{

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -1,0 +1,97 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ObisCode.hpp"
+#include <QTextStream>
+
+ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
+medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(range), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(1), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(1), channel_(0), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(octet_string* obis_code) : 
+medium_(0), channel_(0), value_(0), quantity_(0), group_(0), range_(0), valid_(true)
+{
+    if (obis_code->len == 6)
+    {
+        medium_   = obis_code->str[0];
+        channel_  = obis_code->str[1];
+        value_    = obis_code->str[2];
+        quantity_ = obis_code->str[3];
+        group_    = obis_code->str[4];
+        range_    = obis_code->str[5];
+        valid_    = true;
+    }
+}
+
+QString ObisCode::toObisString() const 
+{
+    QString string;
+
+    if (isValid()){
+        QTextStream s(&string);
+        s << medium_ << "-" << channel_ << ":" << value_ << "." << quantity_ << "." << group_ << "*" << range_;
+    }else{
+        string = QString("Invalid OBIS Code!");
+    }
+
+    return string;
+}
+
+QString ObisCode::toReadableString() const 
+{
+    QString string;
+
+    if (isValid())
+    {
+        string = getName();
+    }else{
+        string = QString("Invalid OBIS Code!");
+    }
+
+    return string;
+}
+
+QString ObisCode::toString() const 
+{
+    QString string;
+
+    if (hasText())
+    {
+        string = toReadableString();
+    }else{
+        string = toObisString();
+    }
+
+    return string;
+}

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -19,6 +19,19 @@
 #include "ObisCode.hpp"
 #include <QTextStream>
 
+const QHash<ObisCode,QString> ObisCode::names_{
+{{1,0,16,7,0}, {"power"}},
+{{1,0,1,8,0}, {"total_consumption"}},
+{{1,0,1,8,1}, {"total_consumption_ch1"}},
+{{1,0,1,8,2}, {"total_consumption_ch2"}},
+{{1,0,2,8,0}, {"total_feed"}},
+{{1,0,2,8,1}, {"total_feed_ch1"}},
+{{1,0,2,8,2}, {"total_feed_ch2"}},
+{{1,0,0,0,9}, {"serial"}},
+{{129,129,199,130,5}, {"public_key"}},
+{{129,129,199,130,3}, {"manufacture"}},
+};
+
 ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
 medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(range), valid_(true)
 {
@@ -54,7 +67,7 @@ medium_(0), channel_(0), value_(0), quantity_(0), group_(0), range_(0), valid_(t
     }
 }
 
-QString ObisCode::toObisString() const 
+const QString ObisCode::toObisString() const 
 {
     QString string;
 
@@ -68,7 +81,7 @@ QString ObisCode::toObisString() const
     return string;
 }
 
-QString ObisCode::toReadableString() const 
+const QString ObisCode::toReadableString() const 
 {
     QString string;
 
@@ -82,7 +95,7 @@ QString ObisCode::toReadableString() const
     return string;
 }
 
-QString ObisCode::toString() const 
+const QString ObisCode::toString() const 
 {
     QString string;
 


### PR DESCRIPTION
Breaking Change: This will change your current mqtt message setup for OBIS messages as IDs will be replaced by resolved names. For filters, both representations (OBIS Code and resolved name) are used for matching.

Feature: Now supporting multiple Filters per value, renaming Datapoints and additional filters