### PR TITLE
[Feature] USB Autoreset for SML device

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Prepare Environment
       shell: bash
       working-directory: ${{github.workspace}}
-      run: sudo apt install -y git cmake build-essential qt5-default qtbase5-dev cmake devscripts qtbase5-private-dev debhelper uuid-dev libqt5xmlpatterns5-dev dh-make libqt5serialport5-dev         
-
+      run: sudo apt install -y git cmake build-essential qtbase5-dev devscripts qtbase5-private-dev debhelper uuid-dev libqt5xmlpatterns5-dev dh-make libqt5serialport5-dev dh-exec
+      
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,8 +35,13 @@ jobs:
       working-directory: ${{github.workspace}}
       run: git clone https://github.com/qt/qtmqtt;
            cd qtmqtt;
-           QT_VERSION=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p');
-           git checkout v$QT_VERSION;
+           QT_VERSION="v$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
+           git tag -l | grep -E "${QT_VERSION}$";
+           if [ $? -ne 0 ]; then 
+           QT_MAJOR=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p');
+           QT_VERSION=$(git tag -l | grep -E "${QT_MAJOR}[0-9]+$" | tail -n 1);
+           fi;
+           git checkout $QT_VERSION;
            cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd qtmqtt-$QT_VERSION;
            qmake;
            dh_make -s -c gpl -e none@none.de --createorig -y;

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,7 +38,7 @@ jobs:
            QT_VERSION="$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
            git tag -l | grep -E "${QT_VERSION}$" || QT_VERSION=$(git tag -l | grep -oP "$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p')[0-9]+$" | tail -n 1);
            git checkout v$QT_VERSION;
-           cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd qtmqtt-$QT_VERSION;
+           cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd "qtmqtt-$QT_VERSION";
            qmake;
            dh_make -s -c gpl -e none@none.de --createorig -y;
            dpkg-buildpackage -b --no-sign;

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,9 +35,9 @@ jobs:
       working-directory: ${{github.workspace}}
       run: git clone https://github.com/qt/qtmqtt;
            cd qtmqtt;
-           QT_VERSION="v$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
-           git tag -l | grep -E "${QT_VERSION}$" || QT_VERSION=$(git tag -l | grep -E "$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p')[0-9]+$" | tail -n 1);
-           git checkout $QT_VERSION;
+           QT_VERSION="$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
+           git tag -l | grep -E "${QT_VERSION}$" || QT_VERSION=$(git tag -l | grep -oP "$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p')[0-9]+$" | tail -n 1);
+           git checkout v$QT_VERSION;
            cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd qtmqtt-$QT_VERSION;
            qmake;
            dh_make -s -c gpl -e none@none.de --createorig -y;

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,11 +36,7 @@ jobs:
       run: git clone https://github.com/qt/qtmqtt;
            cd qtmqtt;
            QT_VERSION="v$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
-           git tag -l | grep -E "${QT_VERSION}$";
-           if [ $? -ne 0 ]; then 
-           QT_MAJOR=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p');
-           QT_VERSION=$(git tag -l | grep -E "${QT_MAJOR}[0-9]+$" | tail -n 1);
-           fi;
+           git tag -l | grep -E "${QT_VERSION}$" || QT_VERSION=$(git tag -l | grep -E "$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p')[0-9]+$" | tail -n 1);
            git checkout $QT_VERSION;
            cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd qtmqtt-$QT_VERSION;
            qmake;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ ADD_EXECUTABLE(SmartMeterToMqtt ${SmartMeterToMqtt_resources} ${SmartMeterToMqtt
 
 set_target_properties(SmartMeterToMqtt PROPERTIES FOLDER "apps")
 target_include_directories(SmartMeterToMqtt PUBLIC "${PROJECT_SOURCE_DIR}/inc")
-TARGET_LINK_LIBRARIES(SmartMeterToMqtt ${EXTRA_LIBS} Qt5::XmlPatterns Qt5::SerialPort Qt5::Mqtt Qt5::Sql Qt5::Network libmbus.so libsml.so Qt5::Xml uuid)
+TARGET_LINK_LIBRARIES(SmartMeterToMqtt ${EXTRA_LIBS} Qt5::XmlPatterns Qt5::SerialPort Qt5::Mqtt Qt5::Sql Qt5::Network libmbus.so libsml.so Qt5::Xml uuid udev)
 
 install(TARGETS SmartMeterToMqtt 
         RUNTIME DESTINATION bin

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ cd libmbus
 cd ..
 
 cd qtmqtt
-QT_VERSION=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p');
-git checkout v$QT_VERSION;
+QT_VERSION="v$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
+git tag -l | grep -E "${QT_VERSION}$";
+if [ $? -ne 0 ]; then 
+QT_MAJOR=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p');
+QT_VERSION=$(git tag -l | grep -E "${QT_MAJOR}[0-9]+$" | tail -n 1);
+fi
+git checkout $QT_VERSION;
 #if no suitable version is found check tags and pick a good one
 cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"
 cd qtmqtt-$QT_VERSION

--- a/README.md
+++ b/README.md
@@ -49,18 +49,12 @@ cd libmbus
 ./build-deb.sh
 cd ..
 
-cd qtmqtt
-QT_VERSION="v$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
-git tag -l | grep -E "${QT_VERSION}$";
-if [ $? -ne 0 ]; then 
-QT_MAJOR=$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p');
-QT_VERSION=$(git tag -l | grep -E "${QT_MAJOR}[0-9]+$" | tail -n 1);
-fi
-git checkout $QT_VERSION;
-#if no suitable version is found check tags and pick a good one
-cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"
-cd qtmqtt-$QT_VERSION
-qmake
+cd qtmqtt;
+QT_VERSION="$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.[0-9]*\)\s*.*/\1/p')";
+git tag -l | grep -E "${QT_VERSION}$" || QT_VERSION=$(git tag -l | grep -oP "$(qmake --version | sed -n  's/.*version\s*\([0-9]*\.[0-9]*\.\)[0-9]*\s*.*/\1/p')[0-9]+$" | tail -n 1);
+git checkout v$QT_VERSION;
+cd .. && mv qtmqtt "qtmqtt-$QT_VERSION"; cd "qtmqtt-$QT_VERSION";
+qmake;
 dh_make -s -c gpl -e none@none.de --createorig -y
 dpkg-buildpackage -b --no-sign
 cd ..

--- a/etc/smartmeter.service.default
+++ b/etc/smartmeter.service.default
@@ -1,6 +1,6 @@
 [Unit]
 Description=SmartMeter
-Documentation=https://gitlab.com/smart-home-tools/smartmetertomqtt
+Documentation=https://github.com/oetken/smartmetertomqtt
 
 [Service]
 Type=simple

--- a/inc/IMessageFilter.hpp
+++ b/inc/IMessageFilter.hpp
@@ -9,6 +9,8 @@
 class IMessageFilter {
 public:
     virtual QVariant filter(QVariant value) = 0;
+    virtual QString  rename(QString name) { return name; };
+    virtual QString  type() = 0;
 };
 
 #endif //SMARTMETERTOMQTT_IMESSAGEFILTER_HPP

--- a/inc/MessageFilterDelta.hpp
+++ b/inc/MessageFilterDelta.hpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,23 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#ifndef SMARTMETERTOMQTT_MESSAGEFILTERDELTA_HPP
+#define SMARTMETERTOMQTT_MESSAGEFILTERDELTA_HPP
 
-#include <QObject>
-#include <QVariant>
 #include "IMessageFilter.hpp"
-#include <QMultiHash>
 
-class IMessageSource : public QObject{
-    Q_OBJECT
+class MessageFilterDelta : public IMessageFilter{
 public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
+    explicit MessageFilterDelta();
+    explicit MessageFilterDelta(QString m_name);
+    QVariant filter(QVariant value) override;
+    QString  rename(QString name) override;
+    QString  type() override { return "Delta"; };
 
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
+private:
+    QVariant m_lastValue;
+    QString m_name;
 };
 
 
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#endif //SMARTMETERTOMQTT_MESSAGEFILTERSKIP_HPP

--- a/inc/MessageFilterIgnore.hpp
+++ b/inc/MessageFilterIgnore.hpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,17 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#ifndef SMARTMETERTOMQTT_MESSAGEFILTERIGNORE_HPP
+#define SMARTMETERTOMQTT_MESSAGEFILTERIGNORE_HPP
 
-#include <QObject>
-#include <QVariant>
 #include "IMessageFilter.hpp"
-#include <QMultiHash>
 
-class IMessageSource : public QObject{
-    Q_OBJECT
+class MessageFilterIgnore : public IMessageFilter{
 public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
-
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
+    explicit MessageFilterIgnore();
+    QVariant filter(QVariant value) override;
+    QString  type() override { return "Ignore"; };
 };
 
 
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#endif //SMARTMETERTOMQTT_MESSAGEFILTERSKIP_HPP

--- a/inc/MessageFilterMean.hpp
+++ b/inc/MessageFilterMean.hpp
@@ -24,7 +24,7 @@ class MessageFilterMean : public IMessageFilter {
 public:
     QVariant filter(QVariant value) override;
     explicit MessageFilterMean(uint32_t sampleCount, double threshold = std::nan(""), uint32_t postThresholdIncreaseSampleCount = 0);
-
+    QString  type() override { return "Mean"; };
 private:
     QVariant getMeanValue(bool force = false);
 

--- a/inc/MessageFilterSkip.hpp
+++ b/inc/MessageFilterSkip.hpp
@@ -22,11 +22,14 @@
 
 class MessageFilterSkip : public IMessageFilter{
 public:
-    explicit MessageFilterSkip(uint32_t skipCount);
+    explicit MessageFilterSkip(uint32_t skipCount, QString name);
     QVariant filter(QVariant value) override;
-
+    QString rename(QString name) override;
+    QString  type() override { return "Skip"; };
+ 
 private:
     uint32_t m_skipCount;
+    QString m_name;
     uint32_t m_skipped{};
 };
 

--- a/inc/MessageSourceMbusSerial.hpp
+++ b/inc/MessageSourceMbusSerial.hpp
@@ -32,6 +32,7 @@ public:
 private slots:
     void readData();
 private:
+    void processFilters(const QString reference, auto value);
     void handleXmlData(char * data);
     QTimer m_timer;
     QString m_device;

--- a/inc/MessageSourceMbusSerial.hpp
+++ b/inc/MessageSourceMbusSerial.hpp
@@ -32,7 +32,7 @@ public:
 private slots:
     void readData();
 private:
-    void processFilters(const QString reference, auto value);
+    void processFilters(const QString reference, const QString value);
     void handleXmlData(char * data);
     QTimer m_timer;
     QString m_device;

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -30,6 +30,10 @@ public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
     bool setup();
     void test();
+private:
+    bool connectUart();
+    void disconnectUart();
+
 private slots:
     void handleReadReady();
     void handleWatchdog();
@@ -40,6 +44,7 @@ private:
     QString topicBase_;
     QString device_;
     uint32_t baudrate_;
+    bool connected_;
     const char startPattern_[8] = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
     const char endPattern_[5] = {0x1b, 0x1b, 0x1b, 0x1b, 0x1a};
     const int dataWatchdogTimeMs_ = 10 * 1000;

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -22,12 +22,14 @@
 #include <QSerialPort>
 #include <QTimer>
 #include "IMessageSource.hpp"
+#include "UsbReset.hpp"
 
 class MessageSourceSml : public IMessageSource
 {
     Q_OBJECT
 public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
+    virtual ~MessageSourceSml(void);
     int32_t setup();
 private:
     void disconnectUart();
@@ -51,6 +53,7 @@ private:
     const int dataWatchdogTimeMs_ = 10 * 1000;
     uint64_t retryTimeMs_ = 30 * 1000;
     QTimer dataWatchdog_;
+    UsbReset* usbReset_;
 };
 
 #endif // MESSAGESOURCESML_H

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -28,7 +28,7 @@ class MessageSourceSml : public IMessageSource
     Q_OBJECT
 public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
-    bool setup();
+    int32_t setup();
 private:
     void disconnectUart();
     bool connectUart(bool retry = false);

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -30,12 +30,14 @@ public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
     bool setup();
 private:
-    bool connectUart();
     void disconnectUart();
+    bool connectUart(bool retry = false);
 
 private slots:
+    void retryConnectUart() { connectUart(true); };
     void handleReadReady();
     void handleWatchdog();
+    void resetUsbDevice();
 
 private:
     QByteArray readData_;
@@ -47,6 +49,7 @@ private:
     const char startPattern_[8] = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
     const char endPattern_[5] = {0x1b, 0x1b, 0x1b, 0x1b, 0x1a};
     const int dataWatchdogTimeMs_ = 10 * 1000;
+    uint64_t retryTimeMs_ = 30 * 1000;
     QTimer dataWatchdog_;
 };
 

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QSerialPort>
+#include <QTimer>
 #include "IMessageSource.hpp"
 
 class MessageSourceSml : public IMessageSource
@@ -28,8 +29,10 @@ class MessageSourceSml : public IMessageSource
 public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
     bool setup();
+    void test();
 private slots:
     void handleReadReady();
+    void handleWatchdog();
 
 private:
     QByteArray readData_;
@@ -39,7 +42,8 @@ private:
     uint32_t baudrate_;
     const char startPattern_[8] = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
     const char endPattern_[5] = {0x1b, 0x1b, 0x1b, 0x1b, 0x1a};
-
+    const int dataWatchdogTimeMs_ = 10 * 1000;
+    QTimer dataWatchdog_;
 };
 
 #endif // MESSAGESOURCESML_H

--- a/inc/MessageSourceSml.hpp
+++ b/inc/MessageSourceSml.hpp
@@ -29,7 +29,6 @@ class MessageSourceSml : public IMessageSource
 public:
     MessageSourceSml(QString topicBase, QString device, uint32_t baudrate);
     bool setup();
-    void test();
 private:
     bool connectUart();
     void disconnectUart();

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -1,0 +1,52 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OBISCODE_H
+#define OBISCODE_H
+
+#include <QString>
+#include "sml/sml_octet_string.h"
+
+class ObisCode
+{
+    
+    public:
+        ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range);
+        ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group);
+        ObisCode(uint8_t channel, uint8_t value, uint8_t quantiy, uint8_t group);
+        ObisCode(uint8_t value, uint8_t quantiy, uint8_t group);
+        ObisCode(octet_string* obis_code);
+
+        bool isValid() const {return valid_;}
+        bool hasText() const {return isValid() && false;} //TODO: Has to be implmented!
+        QString getName() const {return QString();} //TODO: Has to be implmented!
+        QString toObisString() const;
+        QString toReadableString() const;
+        QString toString() const;
+
+    private:
+        uint8_t medium_;
+        uint8_t channel_;
+        uint8_t value_;
+        uint8_t quantity_;
+        uint8_t group_;
+        uint8_t range_;
+        bool    valid_;
+};
+
+#endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -36,8 +36,10 @@ class ObisCode
         ObisCode(octet_string* obis_code);
 
         bool isValid() const {return valid_;}
-        bool hasText() const {return isValid() && names_.contains(*this);} 
-        const QString getName() const {return names_.value(*this);}
+        bool hasName() const {return isValid() && names_.contains(*this);} 
+        bool hasPostfix() const {return isValid() && postfixes_.contains(this.range_);} 
+        const QString getName() const {return hasName() ? names_.value(*this) : "";}
+        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this.range_) : '';}
         const QString toObisString() const;
         const QString toReadableString() const;
         const QString toString() const;
@@ -52,16 +54,20 @@ class ObisCode
         bool    valid_;
 
         static const QHash<ObisCode,QString> names_;
+        static const QHash<uint8_t,QString> postfixes_;
 };
 
 inline bool operator==(const ObisCode &code1, const ObisCode &code2)
 {
-    return code1.toObisString() == code2.toObisString();
+    return code1.medium_   == code2.medium_  &&
+           code1.channel_  == code2.channel_ &&
+           code1.value_    == code2.value_   &&
+           code1.quantity_ == code2.quantity_ &&
+           code1.group_    == code2.group_ ;
 }
 
 inline uint qHash(const ObisCode &key, uint seed)
 {
-    //return qHash(key.toObisString().toLatin1(), seed ^ 0xb036);
     return qHash(key.toObisString(), seed ^ 0xb036);
 }
 #endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -20,7 +20,10 @@
 #define OBISCODE_H
 
 #include <QString>
+#include <QHash>
 #include "sml/sml_octet_string.h"
+
+class ObisCode;
 
 class ObisCode
 {
@@ -33,11 +36,11 @@ class ObisCode
         ObisCode(octet_string* obis_code);
 
         bool isValid() const {return valid_;}
-        bool hasText() const {return isValid() && false;} //TODO: Has to be implmented!
-        QString getName() const {return QString();} //TODO: Has to be implmented!
-        QString toObisString() const;
-        QString toReadableString() const;
-        QString toString() const;
+        bool hasText() const {return isValid() && names_.contains(*this);} 
+        const QString getName() const {return names_.value(*this);}
+        const QString toObisString() const;
+        const QString toReadableString() const;
+        const QString toString() const;
 
     private:
         uint8_t medium_;
@@ -47,6 +50,18 @@ class ObisCode
         uint8_t group_;
         uint8_t range_;
         bool    valid_;
+
+        static const QHash<ObisCode,QString> names_;
 };
 
+inline bool operator==(const ObisCode &code1, const ObisCode &code2)
+{
+    return code1.toObisString() == code2.toObisString();
+}
+
+inline uint qHash(const ObisCode &key, uint seed)
+{
+    //return qHash(key.toObisString().toLatin1(), seed ^ 0xb036);
+    return qHash(key.toObisString(), seed ^ 0xb036);
+}
 #endif // OBISCODE_H

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -44,7 +44,9 @@ class ObisCode
         const QString toReadableString() const;
         const QString toString() const;
 
-    protected:
+        friend bool operator==(const ObisCode &lhs, const ObisCode &rhs);
+
+    private:
         uint8_t medium_;
         uint8_t channel_;
         uint8_t value_;
@@ -58,13 +60,13 @@ class ObisCode
         static const QHash<uint8_t,QString> postfixes_;
 };
 
-inline bool operator==(const ObisCode &code1, const ObisCode &code2)
+inline bool operator==(const ObisCode &lhs, const ObisCode &rhs)
 {
-    return code1.medium_   == code2.medium_  &&
-           code1.channel_  == code2.channel_ &&
-           code1.value_    == code2.value_   &&
-           code1.quantity_ == code2.quantity_ &&
-           code1.group_    == code2.group_ ;
+    return lhs.medium_   == rhs.medium_  &&
+           lhs.channel_  == rhs.channel_ &&
+           lhs.value_    == rhs.value_   &&
+           lhs.quantity_ == rhs.quantity_ &&
+           lhs.group_    == rhs.group_ ;
 }
 
 inline uint qHash(const ObisCode &key, uint seed)

--- a/inc/ObisCode.hpp
+++ b/inc/ObisCode.hpp
@@ -37,14 +37,14 @@ class ObisCode
 
         bool isValid() const {return valid_;}
         bool hasName() const {return isValid() && names_.contains(*this);} 
-        bool hasPostfix() const {return isValid() && postfixes_.contains(this.range_);} 
+        bool hasPostfix() const {return isValid() && postfixes_.contains(this->range_);} 
         const QString getName() const {return hasName() ? names_.value(*this) : "";}
-        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this.range_) : '';}
+        const QString getPostfix() const {return hasPostfix() ? postfixes_.value(this->range_) : "";}
         const QString toObisString() const;
         const QString toReadableString() const;
         const QString toString() const;
 
-    private:
+    protected:
         uint8_t medium_;
         uint8_t channel_;
         uint8_t value_;
@@ -53,6 +53,7 @@ class ObisCode
         uint8_t range_;
         bool    valid_;
 
+    private:
         static const QHash<ObisCode,QString> names_;
         static const QHash<uint8_t,QString> postfixes_;
 };

--- a/inc/SmartMeterToMqtt.hpp
+++ b/inc/SmartMeterToMqtt.hpp
@@ -35,7 +35,7 @@ public:
     bool addMessageSource(IMessageSource * messageSource);
     bool setup();
     bool setupClient(QString hostname, uint16_t port, QString user, QString password, QString clientId = "", uint32_t keepAliveTime = 10);
-    bool publishMqttMessage(QString topic, QVariant message);
+    bool publishMqttMessage(QString topic, QVariant message, bool retain = true);
     bool getMessageSources();
 private:
     bool getFilters(QJsonArray &messageFilters, IMessageSource *filters);

--- a/inc/UsbReset.hpp
+++ b/inc/UsbReset.hpp
@@ -24,16 +24,23 @@
 class UsbReset : public QThread{
     Q_OBJECT
 public:
-    explicit UsbReset();
+    explicit UsbReset(void);
+    explicit UsbReset(const QString device);
+
 public slots:
+    void doReset() { doReset(this->device_); };
     void doReset(const QString device);
+
 protected:
-    QString resolveDevice(const QString) const;
+    QString resolveDevice(const QString device) const;
 
 signals:
     void resetSuccess(QString device);
     void resetFailed(QString device);
     void resetDone(bool success, QString device);
+
+private:
+    QString device_;
 };
 
 

--- a/inc/UsbReset.hpp
+++ b/inc/UsbReset.hpp
@@ -1,0 +1,33 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef SMARTMETERTOMQTT_USBRESET_HPP
+#define SMARTMETERTOMQTT_USBRESET_HPP
+
+class UsbReset : public QThread{
+public:
+    explicit UsbReset();
+public slots:
+    void doReset(const QString device);
+protected:
+    QString resolveDevice(const QString) const;
+signals:
+    void resetDone(bool success, QString device);
+};
+
+
+#endif //SMARTMETERTOMQTT_USBRESET_HPP

--- a/inc/UsbReset.hpp
+++ b/inc/UsbReset.hpp
@@ -18,14 +18,21 @@
 #ifndef SMARTMETERTOMQTT_USBRESET_HPP
 #define SMARTMETERTOMQTT_USBRESET_HPP
 
+#include <QObject>
+#include <QThread>
+
 class UsbReset : public QThread{
+    Q_OBJECT
 public:
     explicit UsbReset();
 public slots:
     void doReset(const QString device);
 protected:
     QString resolveDevice(const QString) const;
+
 signals:
+    void resetSuccess(QString device);
+    void resetFailed(QString device);
     void resetDone(bool success, QString device);
 };
 

--- a/src/MessageFilterDelta.cpp
+++ b/src/MessageFilterDelta.cpp
@@ -1,0 +1,42 @@
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "MessageFilterDelta.hpp"
+
+MessageFilterDelta::MessageFilterDelta() : m_lastValue(QVariant()), m_name(QString()){
+}
+
+MessageFilterDelta::MessageFilterDelta(QString name) : m_lastValue(QVariant()), m_name(name){
+}
+
+QString MessageFilterDelta::rename(QString name) {
+    if (m_name.isEmpty())
+      return name;
+    return m_name;
+}
+
+QVariant MessageFilterDelta::filter(QVariant value) {
+    QVariant delta = QVariant();
+    if (!m_lastValue.isNull() && m_lastValue.canConvert<double>() && value.canConvert<double>())
+      {
+        double old_val = m_lastValue.value<double>();
+        double new_val = value.value<double>();
+        delta.setValue<double>(new_val - old_val);
+      }
+    m_lastValue = value;
+    return delta;
+}

--- a/src/MessageFilterDelta.cpp
+++ b/src/MessageFilterDelta.cpp
@@ -31,12 +31,19 @@ QString MessageFilterDelta::rename(QString name) {
 
 QVariant MessageFilterDelta::filter(QVariant value) {
     QVariant delta = QVariant();
-    if (!m_lastValue.isNull() && m_lastValue.canConvert<double>() && value.canConvert<double>())
+
+    if (value.canConvert<double>())
+    {
+      double new_val = value.value<double>();
+
+      if (!m_lastValue.isNull() && m_lastValue.canConvert<double>())
       {
         double old_val = m_lastValue.value<double>();
-        double new_val = value.value<double>();
         delta.setValue<double>(new_val - old_val);
       }
-    m_lastValue = value;
+
+      m_lastValue.setValue<double>(new_val);
+    }
+    
     return delta;
 }

--- a/src/MessageFilterIgnore.cpp
+++ b/src/MessageFilterIgnore.cpp
@@ -1,4 +1,4 @@
-/*  Copyright 2021 - 2021, Andreas Oetken and the smartmetertomqtt contributors.
+/*  Copyright 2023, Fabian Hassel and the smartmetertomqtt contributors.
 
     This file is part of SmartMeterToMqtt.
 
@@ -15,27 +15,11 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
-#define QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+#include "MessageFilterIgnore.hpp"
 
-#include <QObject>
-#include <QVariant>
-#include "IMessageFilter.hpp"
-#include <QMultiHash>
+MessageFilterIgnore::MessageFilterIgnore(){
+}
 
-class IMessageSource : public QObject{
-    Q_OBJECT
-public:
-    virtual void addFilter(QString datapoint, IMessageFilter * filter)
-    {
-        m_filters.insert(datapoint, filter);
-    }
-signals:
-    void messageReceived(QString topic, QVariant value);
-
-protected:
-    QMultiHash<QString, IMessageFilter *> m_filters;
-};
-
-
-#endif //QSMARTMETERTOMQTT_IMESSAGESOURCE_HPP
+QVariant MessageFilterIgnore::filter(QVariant value) {
+    return QVariant();
+}

--- a/src/MessageFilterSkip.cpp
+++ b/src/MessageFilterSkip.cpp
@@ -17,7 +17,13 @@
  */
 #include "MessageFilterSkip.hpp"
 
-MessageFilterSkip::MessageFilterSkip(uint32_t skipCount) : m_skipCount(skipCount){
+MessageFilterSkip::MessageFilterSkip(uint32_t skipCount, QString name) : m_skipCount(skipCount), m_name(name){
+}
+
+QString MessageFilterSkip::rename(QString name) {
+  if (m_name.isEmpty())
+    return name;
+  return m_name;
 }
 
 QVariant MessageFilterSkip::filter(QVariant value) {

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -261,10 +261,10 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
                             qDebug() << m_topic + "/" + string + "/" + variant.toString();
                         }
                     }
-                    else {
-                        emit messageReceived(m_topic + "/" + string, variant);
-                        qDebug() << m_topic + "/" + string + "/" + variant.toString();
-                    }
+                    // else {
+                    //     emit messageReceived(m_topic + "/" + string, variant);
+                    //     qDebug() << m_topic + "/" + string + "/" + variant.toString();
+                    // }
                 }
             } else {
                 qDebug() << m_topic + "/" + reference + "/" + value;

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -243,32 +243,32 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
                 {
                     qDebug() << "Running filter" << filter->type();
                     QVariant variant = filter->filter(value);
-                    reference = filter->rename(reference);
+                    QString string = filter->rename(reference);
                     if(!variant.isNull())
                     {
                         if(variant.canConvert<QVariantList>())
                         {
                             for(QVariant element : variant.toList())
                             {
-                                emit messageReceived(m_topic + "/" + reference, variant);
-                                qDebug() << m_topic + "/" + reference + "/" + variant.toString();
+                                emit messageReceived(m_topic + "/" + string, variant);
+                                qDebug() << m_topic + "/" + string + "/" + variant.toString();
 
                                 emit messageReceived(m_topic + "/" + name, element);
                                 qDebug() << "filtered" << name << element;
                             }
                         } else {
-                            emit messageReceived(m_topic + "/" + reference, variant);
-                            qDebug() << m_topic + "/" + reference + "/" + variant.toString();
+                            emit messageReceived(m_topic + "/" + string, variant);
+                            qDebug() << m_topic + "/" + string + "/" + variant.toString();
                         }
                     }
                     else {
-                        emit messageReceived(m_topic + "/" + id + "/" + name, variant);
-                        qDebug() << m_topic + "/" + id + "/" + name + "/" + variant.toString();
+                        emit messageReceived(m_topic + "/" + string, variant);
+                        qDebug() << m_topic + "/" + string + "/" + variant.toString();
                     }
                 }
             } else {
-                qDebug() << m_topic + "/" + id + "/" + name + "/" + value;
-                emit messageReceived(m_topic + "/" + id + "/" + name, value);
+                qDebug() << m_topic + "/" + reference + "/" + value;
+                emit messageReceived(m_topic + "/" + reference, value);
             }
         }
     }

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -275,8 +275,8 @@ void MessageSourceMbusSerial::processFilters(const QString reference, auto value
                         emit messageReceived(m_topic + "/" + string, variant);
                         qDebug() << m_topic + "/" + string + "/" + variant.toString();
 
-                        emit messageReceived(m_topic + "/" + name, element);
-                        qDebug() << "filtered" << name << element;
+                        emit messageReceived(m_topic + "/" + string, element);
+                        qDebug() << "filtered" << string << element;
                     }
                 } else {
                     emit messageReceived(m_topic + "/" + string, variant);

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -235,7 +235,7 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
             auto name = children.at(i).nodeName();
             QString reference = "slaveinfo/" + name;
 
-            processFilters(name, value);
+            processFilters(reference, value);
         }
     }
 

--- a/src/MessageSourceMbusSerial.cpp
+++ b/src/MessageSourceMbusSerial.cpp
@@ -256,7 +256,7 @@ void MessageSourceMbusSerial::handleXmlData(char * data)
     }
 }
 
-void MessageSourceMbusSerial::processFilters(const QString reference, auto value){
+void MessageSourceMbusSerial::processFilters(const QString reference, const QString value){
     qDebug() << "Processing MBUS value" << reference;
 
     if(m_filters.contains(reference))

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -142,10 +142,10 @@ void MessageSourceSml::handleReadReady()
                                     qDebug() << "filtered" << string << variant;
                                 }
                             }
-                            else {
-                                emit messageReceived(topicBase_ + "/" + string, variant);
-                                qDebug() << "filtered" << string << variant;
-                            }
+                            // else {
+                            //     emit messageReceived(topicBase_ + "/" + string, variant);
+                            //     qDebug() << "filtered" << string << variant;
+                            // }
                         }
                       } else {
                           emit messageReceived(topicBase_ + "/" + name, value);

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -127,24 +127,24 @@ void MessageSourceSml::handleReadReady()
                         for(auto filter : filters)
                         {
                             QVariant variant = filter->filter(value);
-                            name = filter->rename(name);
+                            QString string = filter->rename(name);
                             if(!variant.isNull())
                             {
                                 if(variant.canConvert<QVariantList>())
                                 {
                                     for(QVariant element : variant.toList())
                                     {
-                                        emit messageReceived(topicBase_ + "/" + name, element);
-                                        qDebug() << "filtered" << name << element;
+                                        emit messageReceived(topicBase_ + "/" + string, element);
+                                        qDebug() << "filtered" << string << element;
                                     }
                                 } else {
-                                    emit messageReceived(topicBase_ + "/" + name, variant);
-                                    qDebug() << "filtered" << name << variant;
+                                    emit messageReceived(topicBase_ + "/" + string, variant);
+                                    qDebug() << "filtered" << string << variant;
                                 }
                             }
                             else {
-                                emit messageReceived(topicBase_ + "/" + name, variant);
-                                qDebug() << "filtered" << name << variant;
+                                emit messageReceived(topicBase_ + "/" + string, variant);
+                                qDebug() << "filtered" << string << variant;
                             }
                         }
                       } else {

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -58,10 +58,10 @@ bool MessageSourceSml::connectUart(bool retry)
     serialPort_.setBaudRate(QSerialPort::BaudRate(baudrate_));
     serialPort_.setPortName(device_);
     if(!serialPort_.open(QIODevice::ReadOnly)) {
-        qDebug() << "Failed to open serial port" << device_ << ":" << serialPort_.errorString();
+        qCritical() << "Failed to open serial port" << device_ << ":" << serialPort_.errorString();
         if (retry){
             resetUsbDevice();
-            qDebug() << "Trying to reconnect after" << retryTimeMs_ << "ms";
+            qCritical() << "Trying to reconnect after" << retryTimeMs_ << "ms";
             QTimer::singleShot(retryTimeMs_, this, &MessageSourceSml::retryConnectUart);
         }
         return false;
@@ -80,6 +80,7 @@ void MessageSourceSml::disconnectUart()
         serialPort_.close();
         connected_ = false;
     }
+    dataWatchdog_.stop();
     serialPort_.clearError();
 }
 

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -298,8 +298,3 @@ void MessageSourceSml::handleWatchdog()
 
     connectUart();
 }
-
-void MessageSourceSml::test()
-{
-    handleWatchdog();
-}

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -52,7 +52,6 @@ int32_t MessageSourceSml::setup() {
 
 bool MessageSourceSml::connectUart(bool retry)
 {
-    // close connection (regardless if connected)
     disconnectUart();
 
     serialPort_.setBaudRate(QSerialPort::BaudRate(baudrate_));

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -35,7 +35,7 @@ MessageSourceSml::MessageSourceSml(QString topicBase, QString device, uint32_t b
 {
 }
 
-bool MessageSourceSml::setup() {
+int32_t MessageSourceSml::setup() {
      // setup data watchdog to detect broken USB connection
     connect(&dataWatchdog_, &QTimer::timeout, this, &MessageSourceSml::handleWatchdog);
     dataWatchdog_.setInterval(dataWatchdogTimeMs_);
@@ -44,9 +44,10 @@ bool MessageSourceSml::setup() {
     bool success = connectUart();
     if(success) {
         connect(&serialPort_, &QSerialPort::readyRead, this, &MessageSourceSml::handleReadReady);
+        return 0;
     }
    
-    return success;
+    return 1;
 }
 
 bool MessageSourceSml::connectUart(bool retry)

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -220,7 +220,7 @@ void MessageSourceSml::handleWatchdog()
 
     disconnectUart();
     resetUsbDevice();
-    connectUart();
+    connectUart(true);
 }
 
 void MessageSourceSml::resetUsbDevice()

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -220,7 +220,8 @@ void MessageSourceSml::handleWatchdog()
 
     disconnectUart();
     resetUsbDevice();
-    connectUart();
+    
+    QTimer::singleShot(2000, this, &MessageSourceSml::retryConnectUart);
 }
 
 void MessageSourceSml::resetUsbDevice()

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -123,7 +123,14 @@ void MessageSourceSml::handleReadReady()
                       QString code = obis.toObisString();
                       if(m_filters.contains(name) || m_filters.contains(code))
                       {
-                        QVariant variant = m_filters.contains(code) ? m_filters[code]->filter(value) : m_filters[name]->filter(value);
+                        QVariant variant;
+                        if(m_filters.contains(name))
+                        {
+                            variant = m_filters[name]->filter(value);
+                        }else{
+                            variant = m_filters[code]->filter(value);
+                        }
+
                         if(!variant.isNull())
                         {
                             if(variant.canConvert<QVariantList>())
@@ -156,4 +163,5 @@ void MessageSourceSml::handleReadReady()
         readData_.remove(0, readData_.length() - sizeof(startPattern_));
     }
 }
+
 

--- a/src/MessageSourceSml.cpp
+++ b/src/MessageSourceSml.cpp
@@ -307,7 +307,7 @@ void MessageSourceSml::resetUsbDevice()
             qDebug() << "Try to execute USBDEVFS_RESET on" << rawDevice;
             int rc = ioctl(fd, USBDEVFS_RESET, 0);
             if (rc == 0){
-                qInfo() << "Sucessfully reseted USB device " << ttyDevice << "via " << rawDevice;
+                qInfo() << "Sucessfully reseted USB device" << ttyDevice << "via" << rawDevice;
                 sucess = true;
             }
             close(fd);

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -20,16 +20,24 @@
 #include <QTextStream>
 
 const QHash<ObisCode,QString> ObisCode::names_{
-{{1,0,16,7,0}, {"power"}},
-{{1,0,1,8,0}, {"total_consumption"}},
-{{1,0,1,8,1}, {"total_consumption_ch1"}},
-{{1,0,1,8,2}, {"total_consumption_ch2"}},
-{{1,0,2,8,0}, {"total_feed"}},
-{{1,0,2,8,1}, {"total_feed_ch1"}},
-{{1,0,2,8,2}, {"total_feed_ch2"}},
-{{1,0,0,0,9}, {"serial"}},
-{{129,129,199,130,5}, {"public_key"}},
-{{129,129,199,130,3}, {"manufacture"}},
+    {{1,0,16,7,0}, {"power"}},
+    {{1,0,1,8,0}, {"total_consumption"}},
+    {{1,0,1,8,1}, {"total_consumption_ch1"}},
+    {{1,0,1,8,2}, {"total_consumption_ch2"}},
+    {{1,0,2,8,0}, {"total_feed"}},
+    {{1,0,2,8,1}, {"total_feed_ch1"}},
+    {{1,0,2,8,2}, {"total_feed_ch2"}},
+    {{1,0,0,0,9}, {"serial"}},
+    {{129,129,199,130,5}, {"public_key"}},
+    {{129,129,199,130,3}, {"manufacture"}}
+};
+
+const QHash<uint8_t,QString> ObisCode::postfixes_{
+    {{96},{"_last1d"}},
+    {{97},{"_last7d"}},
+    {{98},{"_last30d"}},
+    {{99},{"_last365d"}},
+    {{100},{"_since_rst"}},
 };
 
 ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
@@ -87,7 +95,11 @@ const QString ObisCode::toReadableString() const
 
     if (isValid())
     {
-        string = getName();
+        if (hasName()){
+            string = getName() + getPostfix();
+        }else{
+            string = toObisString();
+        }
     }else{
         string = QString("Invalid OBIS Code!");
     }
@@ -99,7 +111,7 @@ const QString ObisCode::toString() const
 {
     QString string;
 
-    if (hasText())
+    if (hasName())
     {
         string = toReadableString();
     }else{

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -1,0 +1,97 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ObisCode.hpp"
+#include <QTextStream>
+
+ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
+medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(range), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(1), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(uint8_t value, uint8_t quantity, uint8_t group) : 
+medium_(1), channel_(0), value_(value), quantity_(quantity), group_(group), range_(255), valid_(true)
+{
+}
+
+ObisCode::ObisCode(octet_string* obis_code) : 
+medium_(0), channel_(0), value_(0), quantity_(0), group_(0), range_(0), valid_(true)
+{
+    if (obis_code->len == 6)
+    {
+        medium_   = obis_code->str[0];
+        channel_  = obis_code->str[1];
+        value_    = obis_code->str[2];
+        quantity_ = obis_code->str[3];
+        group_    = obis_code->str[4];
+        range_    = obis_code->str[5];
+        valid_    = true;
+    }
+}
+
+QString ObisCode::toObisString() const 
+{
+    QString string;
+
+    if (isValid()){
+        QTextStream s(&string);
+        s << medium_ << "-" << channel_ << ":" << value_ << "." << quantity_ << "." << group_ << "*" << range_;
+    }else{
+        string = QString("Invalid OBIS Code!");
+    }
+
+    return string;
+}
+
+QString ObisCode::toReadableString() const 
+{
+    QString string;
+
+    if (isValid())
+    {
+        string = getName();
+    }else{
+        string = QString("Invalid OBIS Code!");
+    }
+
+    return string;
+}
+
+QString ObisCode::toString() const 
+{
+    QString string;
+
+    if (hasText())
+    {
+        string = toReadableString();
+    }else{
+        string = toObisString();
+    }
+
+    return string;
+}

--- a/src/ObisCode.cpp
+++ b/src/ObisCode.cpp
@@ -19,6 +19,19 @@
 #include "ObisCode.hpp"
 #include <QTextStream>
 
+const QHash<ObisCode,QString> ObisCode::names_{
+{{1,0,16,7,0}, {"power"}},
+{{1,0,1,8,0}, {"total_consumption"}},
+{{1,0,1,8,1}, {"total_consumption_ch1"}},
+{{1,0,1,8,2}, {"total_consumption_ch2"}},
+{{1,0,2,8,0}, {"total_feed"}},
+{{1,0,2,8,1}, {"total_feed_ch1"}},
+{{1,0,2,8,2}, {"total_feed_ch2"}},
+{{1,0,0,0,9}, {"serial"}},
+{{129,129,199,130,5}, {"public_key"}},
+{{129,129,199,130,3}, {"manufacture"}},
+};
+
 ObisCode::ObisCode(uint8_t medium, uint8_t channel, uint8_t value, uint8_t quantity, uint8_t group, uint8_t range) : 
 medium_(medium), channel_(channel), value_(value), quantity_(quantity), group_(group), range_(range), valid_(true)
 {
@@ -54,7 +67,7 @@ medium_(0), channel_(0), value_(0), quantity_(0), group_(0), range_(0), valid_(t
     }
 }
 
-QString ObisCode::toObisString() const 
+const QString ObisCode::toObisString() const 
 {
     QString string;
 
@@ -68,7 +81,7 @@ QString ObisCode::toObisString() const
     return string;
 }
 
-QString ObisCode::toReadableString() const 
+const QString ObisCode::toReadableString() const 
 {
     QString string;
 
@@ -82,7 +95,7 @@ QString ObisCode::toReadableString() const
     return string;
 }
 
-QString ObisCode::toString() const 
+const QString ObisCode::toString() const 
 {
     QString string;
 

--- a/src/SmartMeterToMqtt.cpp
+++ b/src/SmartMeterToMqtt.cpp
@@ -272,7 +272,7 @@ bool SmartMeterToMqtt::setupClient(QString hostname, uint16_t port, QString user
 }
 
 
-bool SmartMeterToMqtt::publishMqttMessage(QString topic, QVariant message) {
+bool SmartMeterToMqtt::publishMqttMessage(QString topic, QVariant message, bool retain) {
     QString messageString = QString();
     if (message.type() == QVariant::Double){
         messageString = QString("%1").arg(message.value<double>(), 0, 'g', 12);
@@ -280,7 +280,7 @@ bool SmartMeterToMqtt::publishMqttMessage(QString topic, QVariant message) {
         messageString = message.toString();
     }
     qDebug() << "Sending" << topic << messageString;
-    return (m_client->publish(topic, messageString.toUtf8(),0, true) == -1);
+    return (m_client->publish(topic, messageString.toUtf8(), 0, retain) == -1);
 }
 
 void SmartMeterToMqtt::updateLogStateChange(QMqttClient::ClientState state) {
@@ -299,7 +299,7 @@ void SmartMeterToMqtt::brokerDisconnected() {
 
 void SmartMeterToMqtt::timerTimedout() {
     static uint32_t x = 0;
-    publishMqttMessage("test/test", x++);
+    publishMqttMessage("test/test", x++, false);
 }
 
 bool SmartMeterToMqtt::addMessageSource(IMessageSource *messageSource) {
@@ -308,5 +308,5 @@ bool SmartMeterToMqtt::addMessageSource(IMessageSource *messageSource) {
 }
 
 void SmartMeterToMqtt::messageReceived(QString topic, QVariant message) {
-    publishMqttMessage(topic, message);
+    publishMqttMessage(topic, message, true);
 }

--- a/src/SmartMeterToMqtt.cpp
+++ b/src/SmartMeterToMqtt.cpp
@@ -280,7 +280,7 @@ bool SmartMeterToMqtt::publishMqttMessage(QString topic, QVariant message) {
         messageString = message.toString();
     }
     qDebug() << "Sending" << topic << messageString;
-    return (m_client->publish(topic, messageString.toUtf8()) == -1);
+    return (m_client->publish(topic, messageString.toUtf8(),0, true) == -1);
 }
 
 void SmartMeterToMqtt::updateLogStateChange(QMqttClient::ClientState state) {

--- a/src/UsbReset.cpp
+++ b/src/UsbReset.cpp
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <QDebug>
 #include "UsbReset.hpp"
 
 #ifdef Q_OS_LINUX
@@ -30,7 +31,7 @@ UsbReset::UsbReset() {
 
 }
 
-void UsbReset:doReset(const QString device){
+void UsbReset::doReset(const QString device){
     bool success = false;
 
     #ifdef Q_OS_LINUX
@@ -59,6 +60,12 @@ void UsbReset:doReset(const QString device){
     #else
         qCritical() << "USB-Reset is only supportet on Linux!";
     #endif
+
+    if (success){
+        emit resetSuccess(device);
+    }else{
+        emit resetFailed(device);
+    }
 
     emit resetDone(success, device);
 }
@@ -121,12 +128,12 @@ QString UsbReset::resolveDevice(const QString device) const{
     }
 
     if (bus > 0 && address > 0){
-        rawdevice = QString("/dev/bus/usb/%1/%2").arg(bus,3,10,QChar('0')).arg(address,3,10,QChar('0'));
-        qDebug() << "Found:" << device << "is at" << rawdevice;
+        rawDevice = QString("/dev/bus/usb/%1/%2").arg(bus,3,10,QChar('0')).arg(address,3,10,QChar('0'));
+        qDebug() << "Found:" << device << "is at" << rawDevice;
     }else{
         qCritical() << "Unable to resolve device" << device;
     }
     #endif
 
-    return rawdevice;
+    return rawDevice;
 }

--- a/src/UsbReset.cpp
+++ b/src/UsbReset.cpp
@@ -1,0 +1,132 @@
+/*  Copyright 2023 - 2023, Fabian Hassel and the smartmetertomqtt contributors.
+
+    This file is part of SmartMeterToMqtt.
+
+    SmartMeterToMqtt is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    SmartMeterToMqtt is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with SmartMeterToMqtt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "UsbReset.hpp"
+
+#ifdef Q_OS_LINUX
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <linux/usbdevice_fs.h>
+#include <libudev.h>
+#endif
+
+UsbReset::UsbReset() {
+
+}
+
+void UsbReset:doReset(const QString device){
+    bool success = false;
+
+    #ifdef Q_OS_LINUX
+        if (geteuid() != 0){
+            qCritical() << "USB-Reset requires root privileges!";
+        }else{
+            QString rawDevice = resolveDevice(device);
+
+            if (!rawDevice.isEmpty()){
+                int fd = open(device.toStdString().c_str(), O_WRONLY);
+                if (fd >= 0)
+                {
+                    qDebug() << "Try to execute USBDEVFS_RESET on" << device;
+                    int rc = ioctl(fd, USBDEVFS_RESET, 0);
+                    if (rc == 0){
+                        qInfo() << "Sucessfully reseted USB device " << device << "via " << rawDevice;
+                        success = true;
+                    }
+                    close(fd);
+                }
+                if (!success){
+                    qCritical() << "Unable to reset USB device " << device;
+                }
+            }
+        }
+    #else
+        qCritical() << "USB-Reset is only supportet on Linux!";
+    #endif
+
+    emit resetDone(success, device);
+}
+
+QString UsbReset::resolveDevice(const QString device) const{
+    #ifdef Q_OS_LINUX
+
+    QString rawDevice = QString();
+
+    qDebug() << "Trying to resolve" << device;
+
+    int bus;
+    int address;
+    const char *path;
+    const char *sysattr;
+    struct udev *udev;
+    struct udev_enumerate *enumerate;
+    struct udev_list_entry *devices, *dev_list_entry;
+    struct udev_device *dev;
+
+    bus = -1;
+    address = -1;
+
+    udev = udev_new();
+    if (udev){
+        enumerate = udev_enumerate_new(udev);
+        udev_enumerate_add_match_subsystem(enumerate, "tty");
+        udev_enumerate_scan_devices(enumerate);
+
+        devices = udev_enumerate_get_list_entry(enumerate);
+        udev_list_entry_foreach(dev_list_entry, devices) {
+            path = udev_list_entry_get_name(dev_list_entry);
+            dev = udev_device_new_from_syspath(udev, path);
+
+            if(strcmp(udev_device_get_devnode(dev), device.toStdString().c_str()) == 0)
+            {
+                dev = udev_device_get_parent_with_subsystem_devtype(
+                        dev,
+                        "usb",
+                        "usb_device");
+                sysattr = udev_device_get_sysattr_value(dev, "busnum");
+                if(sysattr != NULL)
+                {
+                    bus = strtol(sysattr, NULL, 10);
+                }
+                sysattr = udev_device_get_sysattr_value(dev, "devnum");
+                if(sysattr != NULL)
+                {
+                    address = strtol(sysattr, NULL, 10);
+                }
+                udev_device_unref(dev);
+                break;
+            }
+            udev_device_unref(dev);
+        }
+        udev_enumerate_unref(enumerate);
+        udev_unref(udev);
+    }else{
+        qCritical() << "UDEV ERROR";
+    }
+
+    if (bus > 0 && address > 0){
+        rawdevice = QString("/dev/bus/usb/%1/%2").arg(bus,3,10,QChar('0')).arg(address,3,10,QChar('0'));
+        qDebug() << "Found:" << device << "is at" << rawdevice;
+    }else{
+        qCritical() << "Unable to resolve device" << device;
+    }
+    #endif
+
+    return rawdevice;
+}


### PR DESCRIPTION
At least with my setup, the connection to the meter interface stucks from time to time. To recover, one must physically re-connect the USB device or issue an USB reset command. In order to prevent freezing values, a SML Data Watchdog - fed by incoming SML data - was implemented. If it times out, the SML-USB device is restarted using the self detected raw device (root privileges checked and required!). This feature is a LINUX only feature.


Fixes #9 